### PR TITLE
Migrate to config.schema

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,9 @@
+# Change Log
+
+# 0.2.0
+
+- Rename `config.yaml` to `config.schema.yaml` and update to use schema.
+
+# 0.1.0
+
+- First release 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,17 @@ additional details.
 
 ## Configuration
 
+Copy the example configuration in [packer.yaml.example](./packer.yaml.example)
+to `/opt/stackstorm/configs/packer.yaml` and edit as required.
+
+It may contain this configuration:
+
 * `exec_path` - full path to packer binary (default: /usr/local/bin/packer)
 * `atlas_token` - Hashicorp Atlas token, needed for `push` action.
+* `variables` - variables passed to Packer. Takes a dict
+
+You can also use dynamic values from the datastore. See the
+[docs](https://docs.stackstorm.com/reference/pack_configs.html) for more info.
 
 ## Actions
 * `packer.build`    - Build images from a packer template

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -1,0 +1,13 @@
+---
+  atlas_token:
+    description: "Hashicorp Atlas token, needed for `push` action"
+    type: "string"
+    secret: true
+  variables:
+    description: "Variables passed to packer. Takes a dict"
+    type: "object"
+    default: {}
+  exec_path:
+    description: "Path to Packer binary. Default /usr/local/bin/packer"
+    type: "string"
+    default: "/usr/local/bin/packer"

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,0 @@
-### Place configuration data for your pack here.
----
-atlas_token: ""
-variables: {}
-#exec_path: "/opt/packer/bin/packer"

--- a/pack.yaml
+++ b/pack.yaml
@@ -1,9 +1,8 @@
-### Place information about your pack version here.
 ---
 ref: packer
 name: packer
 description: Hashicorp Packer builder integration
-version: 0.1.0
+version: 0.2.0
 author: James Fryman
 email: james@stackstorm.com
 keywords:

--- a/packer.yaml.example
+++ b/packer.yaml.example
@@ -1,0 +1,4 @@
+---
+atlas_token: ""
+variables: {}
+exec_path: "/usr/local/bin/packer"


### PR DESCRIPTION
Migrate to `config.schema`

Needs checking that using `type: object` is correct for passing in dict for `variables`.