### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.3.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+
 # 0.2.0
 
 - Rename `config.yaml` to `config.schema.yaml` and update to use schema.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ It may contain this configuration:
 You can also use dynamic values from the datastore. See the
 [docs](https://docs.stackstorm.com/reference/pack_configs.html) for more info.
 
+**Note** : When modifying the configuration in `/opt/stackstorm/configs/` please
+           remember to tell StackStorm to load these new values by running
+           `st2ctl reload --register-configs`
+
 ## Actions
 * `packer.build`    - Build images from a packer template
 * `packer.fix`      - Takes a template and finds backwards

--- a/actions/build.yaml
+++ b/actions/build.yaml
@@ -1,6 +1,6 @@
 ---
 name: "build"
-runner_type: "run-python"
+runner_type: "python-script"
 description: "Build images from a packer template"
 enabled: true
 entry_point: "build.py"

--- a/actions/fix.yaml
+++ b/actions/fix.yaml
@@ -1,6 +1,6 @@
 ---
 name: "fix"
-runner_type: "run-python"
+runner_type: "python-script"
 description: "Takes a template and finds backwards incompatible parts of it and brings it up to date so it can be used with the latest version of Packer"
 enabled: true
 entry_point: "fix.py"

--- a/actions/inspect.yaml
+++ b/actions/inspect.yaml
@@ -1,6 +1,6 @@
 ---
 name: "inspect"
-runner_type: "run-python"
+runner_type: "python-script"
 description: "Takes a template and outputs the various components a template defines"
 enabled: true
 entry_point: "inspect.py"

--- a/actions/push.yaml
+++ b/actions/push.yaml
@@ -1,6 +1,6 @@
 ---
 name: "push"
-runner_type: "run-python"
+runner_type: "python-script"
 description: "Push a template to Hashicorp Atlas"
 enabled: true
 entry_point: "push.py"

--- a/actions/validate.yaml
+++ b/actions/validate.yaml
@@ -1,6 +1,6 @@
 ---
 name: "validate"
-runner_type: "run-python"
+runner_type: "python-script"
 description: "Validate a packer template"
 enabled: true
 entry_point: "validate.py"

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,7 +2,7 @@
 ref: packer
 name: packer
 description: Hashicorp Packer builder integration
-version: 0.2.0
+version: 0.3.0
 author: James Fryman
 email: james@stackstorm.com
 keywords:


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.