### PR TITLE
Feature/setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ from a single source configuration.
 ## Setup
 
 * Install `packer` to be installed on all StackStorm nodes. Please follow the [HashiCorp Packer install guide](https://www.packer.io/intro/getting-started/install.html)
-* Configure the pack, see [configuration](#Configuration) for additional details.
+* Configure the pack, see [Configuration](#Configuration) for additional details.
 
 ## Configuration
 
@@ -16,7 +16,7 @@ to `/opt/stackstorm/configs/packer.yaml` and edit as required.
 
 It may contain this configuration:
 
-* `exec_path` - full path to packer binary (default: /usr/local/bin/packer)
+* `exec_path` - full path to packer binary (default: `/usr/local/bin/packer`)
 * `atlas_token` - Hashicorp Atlas token, needed for `push` action.
 * `variables` - variables passed to Packer. Takes a dict
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@ This integration pack allows StackStorm to control [Packer](http://packer.io),
 a tool for creating machine and container images for multiple platforms
 from a single source configuration.
 
-Requires `packer` to be installed on Worker nodes. See _configuration_ for
-additional details.
+## Setup
+
+* Install `packer` to be installed on all StackStorm nodes. Please follow the [HashiCorp Packer install guide](https://www.packer.io/intro/getting-started/install.html)
+* Configure the pack, see [configuration](#Configuration) for additional details.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ This integration pack allows StackStorm to control [Packer](http://packer.io),
 a tool for creating machine and container images for multiple platforms
 from a single source configuration.
 
+This pack works by invoking the Packer CLI directly on the StackStorm node.
+
 ## Setup
 
-* Install `packer` to be installed on all StackStorm nodes. Please follow the [HashiCorp Packer install guide](https://www.packer.io/intro/getting-started/install.html)
+* Install `packer` on all StackStorm nodes. Please follow the [HashiCorp Packer install guide](https://www.packer.io/intro/getting-started/install.html)
 * Configure the pack, see [Configuration](#Configuration) for additional details.
 
 ## Configuration


### PR DESCRIPTION
Cleaned up the README to include explicit instructions for installing Packer on all StackStorm nodes.